### PR TITLE
Overwriting filter fix

### DIFF
--- a/cli-parser.js
+++ b/cli-parser.js
@@ -339,7 +339,7 @@ Interface.prototype.command = function(cname, config) {
     
     // Overwrite existing commands
     this.commands = this.commands.filter(function(obj) {
-        obj.cname !== cname;
+        return obj.cname !== cname;
     });
 
     this.commands.push(command);


### PR DESCRIPTION
Overwrite filter didn't return anything, resulting in overwriting all commands, no matter the name.
